### PR TITLE
Allow variable amount of blur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-progressive-loader",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Utility to load images and React components progressively, and get code splitting for free",
   "repository": "https://github.com/yosbelms/react-progressive-loader.git",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-progressive-loader",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Utility to load images and React components progressively, and get code splitting for free",
   "repository": "https://github.com/yosbelms/react-progressive-loader.git",
   "main": "lib/index.js",

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -54,6 +54,7 @@ export function Img(props:  HTMLAttributes<any> & {
   delete wrapperProps.placeholderSrc
   delete wrapperProps.bgColor
   delete wrapperProps.loadOnScreen
+  delete wrapperProps.blurAmount
 
   const bgColor = props.bgColor || defaultBgColor
   const blurAmount = props.blurAmount || defaultBlurAmount

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -102,7 +102,7 @@ export function Img(props:  HTMLAttributes<any> & {
   placeholderSrc: PropsTypes.string,
   bgColor: PropsTypes.string,
   loadOnScreen: PropsTypes.bool,
-  blurAmount: PropTypes.number
+  blurAmount: PropsTypes.number
 }
 
 function constructor(cmp) {

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -18,10 +18,12 @@ const imgStyle = {
   transition: 'opacity 1s linear'
 }
 
-const imgPlaceholderStyle = {
-  ...imgStyle,
-  filter: 'blur(50px)',
-  transform: 'scale(1)'
+const imgPlaceholderStyle = blurAmount => {
+  return {
+    ...imgStyle,
+    filter: `blur(${blurAmount})`,
+    transform: 'scale(1)'
+  };
 }
 
 const wrapperStyle = {
@@ -37,12 +39,14 @@ const backgroundStyle = {
 }
 
 const defaultBgColor = '#f6f6f6'
+const defaultBlurAmount = '50px'
 
 export function Img(props:  HTMLAttributes<any> & {
   src: string
   placeholderSrc?: string
   bgColor?: string
   loadOnScreen?: boolean
+  blurAmount?: number
 }) {
   const { src, placeholderSrc } = props
   const wrapperProps = { ...props }
@@ -52,6 +56,7 @@ export function Img(props:  HTMLAttributes<any> & {
   delete wrapperProps.loadOnScreen
 
   const bgColor = props.bgColor || defaultBgColor
+  const blurAmount = props.blurAmount || defaultBlurAmount
 
   return (
     <Bare
@@ -74,7 +79,7 @@ export function Img(props:  HTMLAttributes<any> & {
           <If test={placeholderSrc && cmp.state.placeholderLoaded} then={() =>
             <img key='placeholder'
               src={placeholderSrc}
-              style={{ ...imgPlaceholderStyle, opacity: cmp.state.loaded ? 0 : 1 }}
+              style={{ ...imgPlaceholderStyle(blurAmount), opacity: cmp.state.loaded ? 0 : 1 }}
             />
           } />
 
@@ -96,7 +101,8 @@ export function Img(props:  HTMLAttributes<any> & {
   src: PropsTypes.string.isRequired,
   placeholderSrc: PropsTypes.string,
   bgColor: PropsTypes.string,
-  loadOnScreen: PropsTypes.bool
+  loadOnScreen: PropsTypes.bool,
+  blurAmount: PropTypes.number
 }
 
 function constructor(cmp) {

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -103,7 +103,7 @@ export function Img(props:  HTMLAttributes<any> & {
   placeholderSrc: PropsTypes.string,
   bgColor: PropsTypes.string,
   loadOnScreen: PropsTypes.bool,
-  blurAmount: PropsTypes.number
+  blurAmount: PropsTypes.string
 }
 
 function constructor(cmp) {

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -54,6 +54,7 @@ export function Img(props: HTMLAttributes<any> & {
   delete wrapperProps.src
   delete wrapperProps.placeholderSrc
   delete wrapperProps.bgColor
+  delete wrapperProps.aspectRatio
   delete wrapperProps.loadOnScreen
   delete wrapperProps.blurAmount
 


### PR DESCRIPTION
Provide a prop, `blurAmount`, which allows the user to control how blurred the placeholder image is.

Usage: Add the `blurAmount` prop with the amount of desired blur.
```js
<Img
    src={img}
    placeholderSrc={imgSmall}
    bgColor={"#f0f0f0"}
    blurAmount={"5px"}
/>
```