### PR TITLE
Remove redundant dom in Img component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "prepublish": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@types/prop-types": "^15.5.3",
     "prop-types": "^15.6.2",
     "react-deco": "^0.7.0"
   },
   "devDependencies": {
+    "@types/prop-types": "^15.5.3",
     "@types/enzyme": "^3.1.11",
     "@types/jasmine": "^2.8.8",
     "@types/react": "^16.4.14",

--- a/src/img.tsx
+++ b/src/img.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as PropsTypes from 'prop-types'
 import { Bare, If } from 'react-deco'
 import { observe } from './observer'
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes } from 'react'
 
 // https://jmperezperez.com/medium-image-progressive-loading-placeholder/
 // https://code.fb.com/android/the-technology-behind-preview-photos/
@@ -34,7 +34,8 @@ const wrapperStyle = {
 }
 
 const backgroundStyle = {
-  ...imgStyle,
+  transition: 'opacity 1s linear',
+  width: '100%',
   height: '100%',
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat'
@@ -97,17 +98,15 @@ export function Img(props: HTMLAttributes<any> & {
             style={{
               ...backgroundStyle,
               backgroundColor: bgColor,
-              opacity: (cmp.state.imageReady || cmp.state.placeholderLoaded) ? 0 : .99
+              opacity: (cmp.state.imageReady || cmp.state.placeholderLoaded) ? 0 : .99,
+              paddingBottom: (
+                getPreserverPaddingBottom(Number(props.aspectRatio)) ||
+                getPreserverPaddingBottom(Number(cmp.state.aspectRatio)) ||
+                getPreserverPaddingBottom(.5)
+              )
             }}
           />
 
-          <div key='preserver' style={{
-            paddingBottom: (
-              getPreserverPaddingBottom(Number(props.aspectRatio)) ||
-              getPreserverPaddingBottom(Number(cmp.state.aspectRatio)) ||
-              getPreserverPaddingBottom(.5)
-            )
-          }} />
         </div>
       } />
   )


### PR DESCRIPTION
There is no need for the last `div` in order to preserve the image ration, the bg `div` can be used as the aspect ratio preserver.

BTW, the best approach of aspect ratio preservation is by using pseudo element, I guess that you didn't used this approach because all your styles are inline.

```css
.lazy-loaded {
    position:relative;
}
.lazy-loaded:after {
    padding-top: var(--aspectRatio);
    width: 100%;
    content: '';
    display:block;
}
```

```javascript
<div data-wrapper class="lazy-loaded" style={{ '--aspectRatio': '70%' }}>
  <img src="...." />
</div>

```